### PR TITLE
Allow for conditional inclusion of kit files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,10 @@ const starterKitStarter = ({
         }
 
         if (path.extname(file) === dynamicExtension) {
-          fileMap[adjustedRelativePath] = require(file)(answers);
+          const fileOutput = require(file)(answers);
+          if (fileOutput) {
+            fileMap[adjustedRelativePath] = require(file)(answers);
+          }
         } else {
           fileMap[adjustedRelativePath] = fs.readFileSync(file, "utf8");
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starter-kit-starter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "./index.js",
   "dependencies": {
     "mkdirp": "0.5.1",


### PR DESCRIPTION
If a `.kit` file returns a falsy value, it will just not include the file in the output.