### PR TITLE
patch: generate error when the kit directory is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ const starterKitStarter = ({
     recursiveReaddir(kitDirectory, (err, files) => {
       const fileMap = {};
 
+      if (!files) {
+        console.error(`No files found in ${kitDirectory}`);
+      }
+
       files.forEach(file => {
         const [, relativePath] = file.split(path.join(kitDirectory, path.sep));
         const adjustedRelativePath = relativePath.replace(dynamicExtension, "");


### PR DESCRIPTION
A simple fix to something that puzzled me starting out: better diagnostics.