### PR TITLE
Allow awaiting starterKitStarter for a better dx

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ declare function starterKitStarter({
   kitDirectory: string, // some magic in here!
   prompt: Promise<PromptResult>,
   finalizeKit: (FilepathsContentsMap, PromptResult) => FilepathsContentsMap
-}): void;
+}): Promise<void>;
 ```
 
 #### example!

--- a/index.js
+++ b/index.js
@@ -1,11 +1,7 @@
 const recursiveReaddir = require('recursive-readdir');
-const mkdirpCB = require('mkdirp');
 const path = require('path');
-const fs = require('fs');
-const util = require('util');
-
-const writeFile = util.promisify(fs.writeFile);
-const mkdirp = util.promisify(mkdirpCB);
+const fs = require('fs').promises;
+const {readFileSync} = require('fs');
 
 const starterKitStarter = ({
   kitDirectory,
@@ -31,7 +27,7 @@ const starterKitStarter = ({
             fileMap[adjustedRelativePath] = require(file)(answers);
           }
         } else {
-          fileMap[adjustedRelativePath] = fs.readFileSync(file, 'utf8');
+          fileMap[adjustedRelativePath] = readFileSync(file, 'utf8');
         }
       });
 
@@ -39,9 +35,10 @@ const starterKitStarter = ({
       return Promise.all(
         Object.keys(finalFiles).map(adjustedRelativePath => {
           const finalPath = path.join(outputDirectory, adjustedRelativePath);
-          return mkdirp(path.dirname(finalPath))
+          return fs
+            .mkdir(path.dirname(finalPath), {recursive: true})
             .then(() => {
-              return writeFile(finalPath, finalFiles[adjustedRelativePath]);
+              return fs.writeFile(finalPath, finalFiles[adjustedRelativePath]);
             })
             .catch(error => {
               console.error(error);

--- a/index.js
+++ b/index.js
@@ -1,22 +1,26 @@
-const recursiveReaddir = require("recursive-readdir");
-const mkdirp = require("mkdirp");
-const path = require("path");
-const fs = require("fs");
+const recursiveReaddir = require('recursive-readdir');
+const mkdirpCB = require('mkdirp');
+const path = require('path');
+const fs = require('fs');
+const util = require('util');
+
+const writeFile = util.promisify(fs.writeFile);
+const mkdirp = util.promisify(mkdirpCB);
 
 const starterKitStarter = ({
   kitDirectory,
   outputDirectory,
   prompt = Promise.resolve({}),
   finalizeKit = identity => identity,
-  dynamicExtension = ".kit"
+  dynamicExtension = '.kit',
 }) => {
-  prompt.then(answers => {
-    recursiveReaddir(kitDirectory, (err, files) => {
+  return prompt.then(answers => {
+    return recursiveReaddir(kitDirectory).then(files => {
       const fileMap = {};
 
       files.forEach(file => {
         const [, relativePath] = file.split(path.join(kitDirectory, path.sep));
-        const adjustedRelativePath = relativePath.replace(dynamicExtension, "");
+        const adjustedRelativePath = relativePath.replace(dynamicExtension, '');
         if (fileMap[adjustedRelativePath]) {
           console.error(`Conflicting paths - ${adjustedRelativePath}`);
         }
@@ -27,23 +31,23 @@ const starterKitStarter = ({
             fileMap[adjustedRelativePath] = require(file)(answers);
           }
         } else {
-          fileMap[adjustedRelativePath] = fs.readFileSync(file, "utf8");
+          fileMap[adjustedRelativePath] = fs.readFileSync(file, 'utf8');
         }
       });
 
       const finalFiles = finalizeKit(fileMap, answers);
-      Object.keys(finalFiles).forEach(adjustedRelativePath => {
-        const finalPath = path.join(outputDirectory, adjustedRelativePath);
-        mkdirp(path.dirname(finalPath), err => {
-          if (err) {
-            console.error(err);
-          }
-
-          fs.writeFile(finalPath, finalFiles[adjustedRelativePath], err => {
-            if (err) console.error(err);
-          });
-        });
-      });
+      return Promise.all(
+        Object.keys(finalFiles).map(adjustedRelativePath => {
+          const finalPath = path.join(outputDirectory, adjustedRelativePath);
+          return mkdirp(path.dirname(finalPath))
+            .then(() => {
+              return writeFile(finalPath, finalFiles[adjustedRelativePath]);
+            })
+            .catch(error => {
+              console.error(error);
+            });
+        })
+      );
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "starter-kit-starter",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "main": "./index.js",
   "dependencies": {
-    "mkdirp": "0.5.1",
     "recursive-readdir": "2.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,18 +27,6 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
 recursive-readdir@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"


### PR DESCRIPTION
Currently we have no way to `await` `starterKitStarter` since it does not return a promise. This change makes it return a promise, and also awaits all promises in between. This makes for a better developer experience both in writing tests AND if you want to display a message after it completes (without depending on `finalizeKit`).